### PR TITLE
Add event subscription handshake and NUL message terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ go build
 ./cotlogger -format json -output data.json -verbose
 ```
 
+### Handshake Behavior
+After connecting, `cotlogger` sends `<takserver><subscribe>event</subscribe></takserver>` to request the event stream. Some servers expect a simpler `<hello/>` message. Use the `-handshake` flag to change this if needed.
+
 ## Installation
 
 ### From Source
@@ -105,6 +108,7 @@ make install            # Install to /usr/local/bin
 | `-reconnect` | `30s` | Reconnection interval |
 | `-read-timeout` | `30s` | Socket read timeout |
 | `-write-timeout` | `30s` | Socket write timeout |
+| `-handshake` | `<takserver><subscribe>event</subscribe></takserver>` | Initial subscription message |
 | `-verbose` | `false` | Enable verbose logging |
 | `-version` | `false` | Show version information |
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,10 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -62,6 +66,7 @@ type Config struct {
 	OutputFile        string
 	OutputFormat      string // raw, formatted, json
 	Verbose           bool
+	Handshake         string
 }
 
 // CoTLogger represents the main logger instance
@@ -69,6 +74,7 @@ type CoTLogger struct {
 	config       Config
 	logger       *slog.Logger
 	conn         net.Conn
+	reader       *bufio.Reader
 	mu           sync.RWMutex
 	done         chan struct{}
 	outputFile   *os.File
@@ -103,6 +109,7 @@ func main() {
 		reconnectInterval = flag.Duration("reconnect", 30*time.Second, "Reconnection interval")
 		readTimeout       = flag.Duration("read-timeout", 30*time.Second, "Read timeout")
 		writeTimeout      = flag.Duration("write-timeout", 30*time.Second, "Write timeout")
+		handshake         = flag.String("handshake", "<takserver><subscribe>event</subscribe></takserver>", "Handshake message")
 		verbose           = flag.Bool("verbose", false, "Enable verbose logging")
 		showVersion       = flag.Bool("version", false, "Show version information")
 	)
@@ -142,6 +149,7 @@ func main() {
 		OutputFile:        *outputFile,
 		OutputFormat:      *outputFormat,
 		Verbose:           *verbose,
+		Handshake:         *handshake,
 	}
 
 	// Validate configuration
@@ -281,10 +289,18 @@ func (c *CoTLogger) connect(ctx context.Context) error {
 	}
 
 	c.conn = conn
+	c.reader = bufio.NewReader(conn)
 	c.logger.Info("connected to TAK server",
 		"host", c.config.Host,
 		"port", c.config.Port,
 		"protocol", c.config.Protocol)
+
+	if err := c.sendHandshake(); err != nil {
+		conn.Close()
+		c.conn = nil
+		c.reader = nil
+		return fmt.Errorf("handshake failed: %w", err)
+	}
 
 	return nil
 }
@@ -361,6 +377,28 @@ func (c *CoTLogger) connectSSL() (net.Conn, error) {
 	return tlsConn, nil
 }
 
+// sendHandshake writes the initial subscription message to the server
+func (c *CoTLogger) sendHandshake() error {
+	if c.config.Handshake == "" {
+		return nil
+	}
+
+	msg := c.config.Handshake
+	// append newline if no terminator provided
+	if !strings.HasSuffix(msg, "\n") && !strings.HasSuffix(msg, "\x00") {
+		msg += "\n"
+	}
+
+	if c.config.WriteTimeout > 0 {
+		if err := c.conn.SetWriteDeadline(time.Now().Add(c.config.WriteTimeout)); err != nil {
+			return fmt.Errorf("failed to set write deadline: %w", err)
+		}
+	}
+
+	_, err := c.conn.Write([]byte(msg))
+	return err
+}
+
 // processMessages handles the message processing loop
 func (c *CoTLogger) processMessages(ctx context.Context) error {
 	for {
@@ -399,28 +437,44 @@ func (c *CoTLogger) processMessages(ctx context.Context) error {
 
 // readMessage reads a single message from the connection
 func (c *CoTLogger) readMessage() (string, error) {
-	buffer := make([]byte, 8192)
-
 	c.mu.RLock()
 	conn := c.conn
+	reader := c.reader
 	c.mu.RUnlock()
 
-	if conn == nil {
+	if conn == nil || reader == nil {
 		return "", fmt.Errorf("connection is nil")
 	}
 
-	if c.config.ReadTimeout > 0 {
-		if err := conn.SetReadDeadline(time.Now().Add(c.config.ReadTimeout)); err != nil {
-			return "", fmt.Errorf("failed to set read deadline: %w", err)
+	var buf bytes.Buffer
+	for {
+		if c.config.ReadTimeout > 0 {
+			if err := conn.SetReadDeadline(time.Now().Add(c.config.ReadTimeout)); err != nil {
+				return "", fmt.Errorf("failed to set read deadline: %w", err)
+			}
 		}
+
+		b, err := reader.ReadByte()
+		if err != nil {
+			if err == io.EOF && buf.Len() > 0 {
+				break
+			}
+			return "", err
+		}
+
+		if b == '\n' || b == 0x00 {
+			break
+		}
+
+		buf.WriteByte(b)
 	}
 
-	n, err := conn.Read(buffer)
+	data, err := decompressIfNeeded(buf.Bytes())
 	if err != nil {
 		return "", err
 	}
 
-	return string(buffer[:n]), nil
+	return string(data), nil
 }
 
 // logMessage logs a CoT message according to the configured format
@@ -527,4 +581,33 @@ func isTimeout(err error) bool {
 		return netErr.Timeout()
 	}
 	return false
+}
+
+// decompressIfNeeded decompresses gzip or zlib data if detected
+func decompressIfNeeded(data []byte) ([]byte, error) {
+	if len(data) < 2 {
+		return data, nil
+	}
+
+	// gzip
+	if data[0] == 0x1f && data[1] == 0x8b {
+		r, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		return io.ReadAll(r)
+	}
+
+	// zlib
+	if data[0] == 0x78 {
+		r, err := zlib.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		return io.ReadAll(r)
+	}
+
+	return data, nil
 }


### PR DESCRIPTION
## Summary
- implement configurable TAK handshake message
- read CoT messages until newline or NUL terminator
- decompress zlib or gzip streams if needed
- document handshake flag and default behavior

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683db732310c8324bf2e579c0f106d64