### PR TITLE
Remove output flag and log to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,12 @@ test:
 
 # Run with sample configuration
 run-tcp:
-	@echo "Running cotlogger with TCP connection..."
-	./$(BINARY_NAME) -host localhost -port 8089 -protocol tcp -output test.log -verbose
+       @echo "Running cotlogger with TCP connection..."
+       ./$(BINARY_NAME) -host localhost -port 8089 -protocol tcp -verbose > test.log
 
 run-ssl:
-	@echo "Running cotlogger with SSL connection..."
-	./$(BINARY_NAME) -host localhost -port 8089 -protocol ssl -cert certs/client.crt -key certs/client.key -ca certs/ca.crt -output test-ssl.log -verbose
+       @echo "Running cotlogger with SSL connection..."
+       ./$(BINARY_NAME) -host localhost -port 8089 -protocol ssl -cert certs/client.crt -key certs/client.key -ca certs/ca.crt -verbose > test-ssl.log
 
 # Development helpers
 dev: build run-tcp

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ cd cotlogger
 go build
 
 # Basic usage - TCP connection
-./cotlogger -host your-tak-server.com -port 8089 -output messages.log
+./cotlogger -host your-tak-server.com -port 8089 > messages.log
 
 # SSL connection with certificates
-./cotlogger -host secure-tak.mil -protocol ssl -cert client.crt -key client.key -ca ca.crt
+./cotlogger -host secure-tak.mil -protocol ssl -cert client.crt -key client.key -ca ca.crt > secure-messages.log
 
 # JSON output for analysis tools
-./cotlogger -format json -output data.json -verbose
+./cotlogger -format json -verbose > data.json
 ```
 
 ## Installation
@@ -59,7 +59,7 @@ make install            # Install to /usr/local/bin
 
 ### Basic TCP Monitoring
 ```bash
-./cotlogger -host tak.example.com -port 8089 -output messages.log -verbose
+./cotlogger -host tak.example.com -port 8089 -verbose > messages.log
 ```
 
 ### Secure SSL Connection
@@ -70,12 +70,12 @@ make install            # Install to /usr/local/bin
   -cert /path/to/client.crt \
   -key /path/to/client.key \
   -ca /path/to/ca.crt \
-  -output secure-messages.log
+  > secure-messages.log
 ```
 
 ### JSON Output for Analysis
 ```bash
-./cotlogger -format json -output cot-data.json -verbose
+./cotlogger -format json -verbose > cot-data.json
 ```
 
 ### High-Volume Production Monitoring
@@ -85,8 +85,8 @@ make install            # Install to /usr/local/bin
   -protocol ssl \
   -embedded-certs \
   -format raw \
-  -output /var/log/tak/cot-$(date +%Y%m%d).log \
-  -reconnect 5s
+  -reconnect 5s \
+  > /var/log/tak/cot-$(date +%Y%m%d).log
 ```
 
 ## Command Line Options
@@ -100,7 +100,6 @@ make install            # Install to /usr/local/bin
 | `-cert` | | Client certificate file (SSL mode) |
 | `-key` | | Client private key file (SSL mode) |
 | `-ca` | | CA certificate file (SSL mode) |
-| `-output` | `cotlogger.log` | Output log file path |
 | `-format` | `formatted` | Output format (`raw`, `formatted`, `json`) |
 | `-reconnect` | `30s` | Reconnection interval |
 | `-read-timeout` | `30s` | Socket read timeout |
@@ -190,13 +189,13 @@ Monitor TAK traffic patterns, connection issues, and message flow:
 ### Security Analysis
 Capture traffic for security auditing and threat analysis:
 ```bash
-./cotlogger -format json -output audit-$(date +%Y%m%d).json
+./cotlogger -format json -verbose > audit-$(date +%Y%m%d).json
 ```
 
 ### Performance Testing
 Monitor high-volume environments:
 ```bash
-./cotlogger -format raw -output perf-test.log -verbose
+./cotlogger -format raw -verbose > perf-test.log
 ```
 
 ### Development & Debugging

--- a/examples/basic-usage.sh
+++ b/examples/basic-usage.sh
@@ -10,23 +10,23 @@ make build
 echo
 
 echo "1. Basic TCP connection:"
-echo "./cotlogger -host localhost -port 8089 -output test-tcp.log -verbose"
+echo "./cotlogger -host localhost -port 8089 -verbose > test-tcp.log"
 echo
 
 echo "2. SSL connection with certificate files:"
-echo "./cotlogger -host secure-tak.mil -protocol ssl -cert client.crt -key client.key -ca ca.crt -output test-ssl.log"
+echo "./cotlogger -host secure-tak.mil -protocol ssl -cert client.crt -key client.key -ca ca.crt > test-ssl.log"
 echo
 
 echo "3. JSON output for analysis:"
-echo "./cotlogger -format json -output test.json -verbose"
+echo "./cotlogger -format json -verbose > test.json"
 echo
 
 echo "4. Raw output with custom reconnect interval:"
-echo "./cotlogger -format raw -output test-raw.log -reconnect 10s -verbose"
+echo "./cotlogger -format raw -reconnect 10s -verbose > test-raw.log"
 echo
 
 echo "5. High-volume monitoring with embedded certs:"
-echo "./cotlogger -protocol ssl -embedded-certs -format raw -output production.log"
+echo "./cotlogger -protocol ssl -embedded-certs -format raw > production.log"
 echo
 
 echo "Run any of these commands after updating the hostnames and certificate paths!"


### PR DESCRIPTION
## Summary
- simplify configuration by removing output file option
- default logging output to stdout
- update examples, README, and Makefile to use shell redirection

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_683db72c16388324926e234251cda3f7